### PR TITLE
Add talk "Scaling Redis at Twitter"

### DIFF
--- a/README.md
+++ b/README.md
@@ -744,6 +744,7 @@ An updated and curated list of readings to illustrate best practices and pattern
 * [Scaling Counting Infrastructure at Quora - Chun-Ho Hung and Nikhil Gar, SEs at Quora](https://www.infoq.com/presentations/quora-analytics)
 * [Scaling Git at Microsoft - Saeed Noursalehi, Principal Program Manager at Microsoft](https://www.youtube.com/watch?v=g_MPGU_m01s)
 * [Scaling Multitenant Architecture Across Multiple Data Centres at Shopify - Weingarten, Engineering Lead at Shopify](https://www.youtube.com/watch?v=F-f0-k46WVk)
+* [Scaling Redis at Twitter](https://www.youtube.com/watch?v=rP9EKvWt0zo)
 
 ## Book
 * [Big Data, Web Ops & DevOps Ebooks - O'Reilly (Online - Free)](http://www.oreilly.com/webops/free/)


### PR DESCRIPTION
Talk by Yao Yu at the San Francisco Redis Meetup group about scaling Redis at Twitter.

> Twitter runs some of the largest Redis clusters in production. To adapt Redis to Twitter's use cases, we have come up with both configuration best practices and several new features. This talk is to provide a case study of running Redis at scale- with numbers and stories, and what we have in mind for the future.