### PR TITLE
From bare-metal-to-Kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ An organized reading list for illustrating the patterns behind scalable, reliabl
 	* [Deconstructing Monolithic Applications into (Kafka-driven) Services at Heroku](https://blog.heroku.com/monolithic-applications-into-services)
 	* [Docker Containers that Power Over 100.000 Online Shops at Shopify](https://shopifyengineering.myshopify.com/blogs/engineering/docker-at-shopify-how-we-built-containers-that-power-over-100-000-online-shops)
 	* [Microservice Architecture at Medium](https://medium.engineering/microservice-architecture-at-medium-9c33805eb74f)
+	* [From bare-metal to Kubernetes](https://boxunix.com/post/bare_metal_to_kube/)
+	
 * [Distributed Caching](https://www.wix.engineering/single-post/scaling-to-100m-to-cache-or-not-to-cache)
 	* [Read-Through, Write-Through, Write-Behind, and Refresh-Ahead Caching](https://docs.oracle.com/cd/E15357_01/coh.360/e15723/cache_rtwtwbra.htm#COHDG5177)
 	* [Eviction Policy and Expiration Policy](http://highscalability.com/blog/2016/1/25/design-of-a-modern-cache.html)


### PR DESCRIPTION
Great article explaining how Betabrand, a clothing company migrated its infrastructure from Rackspace to Kubernetes.!