### PR TITLE
add: Goods - Organizing Google's Datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,6 +619,7 @@ An updated and organized reading list for illustrating the patterns of scalable,
 	* [Keystone: Real-time Stream Processing Platform at Netflix](https://medium.com/netflix-techblog/keystone-real-time-stream-processing-platform-a3ee651812a)
 	* [Databook: Turning Big Data into Knowledge with Metadata at Uber](https://eng.uber.com/databook/)
 	* [Amundsen: Data Discovery & Metadata Engine at Lyft](https://eng.lyft.com/amundsen-lyfts-data-discovery-metadata-engine-62d27254fbb9)
+	* [Goods: Organizing Google's Datasets](https://ai.google/research/pubs/pub45390)
 	* [Maze: Funnel Visualization Platform at Uber](https://eng.uber.com/maze/)
 	* [Metacat: Making Big Data Discoverable and Meaningful at Netflix](https://medium.com/netflix-techblog/metacat-making-big-data-discoverable-and-meaningful-at-netflix-56fb36a53520)
 	* [SpinalTap: Change Data Capture System at Airbnb](https://medium.com/airbnb-engineering/capturing-data-evolution-in-a-service-oriented-architecture-72f7c643ee6f)


### PR DESCRIPTION
I added this item closer to the one it's the most relevant - the excellent  [Amundsen: Data Discovery & Metadata Engine at Lyft](https://eng.lyft.com/amundsen-lyfts-data-discovery-metadata-engine-62d27254fbb9) since it brings a complementary perspective. 

By doing this, I broke the contributing rule _Link additions should be added to the bottom of the relevant category._ for the sake of consistency. I can adjust it if the maintainer of the project prefers so.