### PR TITLE
Fix broken Rackspace link

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ An updated and organized reading list for illustrating the patterns of scalable,
 * [Performance is a Feature](https://blog.codinghorror.com/performance-is-a-feature/)
 * [Make Performance Part of Your Workflow](https://codeascraft.com/2014/12/11/make-performance-part-of-your-workflow/)
 * [The Benefits of Server Side Rendering over Client Side Rendering](https://medium.com/walmartlabs/the-benefits-of-server-side-rendering-over-client-side-rendering-5d07ff2cefe8)
-* [Writing Code that Scales](https://blog.rackspace.com/writing-code-that-scales)
+* [Writing Code that Scales](https://web.archive.org/web/20190822121819/https://blog.rackspace.com/writing-code-that-scales)
 * [Automate and Abstract: Lessons at Facebook](https://architecht.io/lessons-from-facebook-on-engineering-for-scale-f5716f0afc7a)
 * [AWS Do's and Don'ts](https://8thlight.com/blog/sarah-sunday/2017/09/15/aws-dos-and-donts.html)
 * [(UI) Design Doesn’t Scale - Stanley Wood, Design Director at Spotify](https://medium.com/@hellostanley/design-doesnt-scale-4d81e12cbc3e)


### PR DESCRIPTION
The link to the Rackspace blog post was broken and it seems like Rackspace has actually removed some of the older blog posts like this one. Fortunately Wayback Machine had a copy of it.