### PR TITLE
Removed obsolete link from architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -797,7 +797,6 @@ An updated and organized reading list for illustrating the patterns of scalable,
 	* [Optimizing Payments with Machine Learning at Dropbox](https://dropbox.tech/machine-learning/optimizing-payments-with-machine-learning)
 
 ## Architecture
-* [Systems We Make](https://systemswemake.com/)
 * [Tech Stack (2 parts) at Uber](https://eng.uber.com/tech-stack-part-two/)
 * [Tech Stack at Medium](https://medium.engineering/the-stack-that-helped-medium-drive-2-6-millennia-of-reading-time-e56801f7c492)
 * [Tech Stack at Shopify](https://engineering.shopify.com/blogs/engineering/e-commerce-at-scale-inside-shopifys-tech-stack)


### PR DESCRIPTION
In architecture section there is this link:
[Systems We Make](https://systemswemake.com/)
Apparently this website is no longer available.