### PR TITLE
Adding Roadmap links of Frontend, Backend & DevOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ An updated and organized reading list for illustrating the patterns of scalable,
 - [Organization](#organization)
 - [Talk](#talk)
 - [Book](#book)
+- [Roadmap](#roadmap)
 
 ## Principle
 * [Lessons from Giant-Scale Services - Eric Brewer, UC Berkeley & Google](https://people.eecs.berkeley.edu/~brewer/papers/GiantScale-IEEE.pdf)
@@ -959,6 +960,13 @@ An updated and organized reading list for illustrating the patterns of scalable,
 * [The Art of Scalability](http://theartofscalability.com/)
 * [Web Scalability for Startup Engineers](https://www.goodreads.com/book/show/23615147-web-scalability-for-startup-engineers)
 * [Scalability Rules: 50 Principles for Scaling Web Sites](http://scalabilityrules.com/)
+
+
+## Roadmap
+* [Frontend Roadmap](https://roadmap.sh/frontend)
+* [Backend Roadmap](https://roadmap.sh/backend)
+* [DevOps Roadmap](https://roadmap.sh/devops)
+
 
 ## Donation
 Roses are red. Violets are blue. [Binh](https://nguyenquocbinh.org/) likes sweet. [Treat Binh a tiramisu?](https://paypal.me/binhnguyennus) :cake:


### PR DESCRIPTION
Hi Binh,

I came across your repository [awesome-scalability](https://github.com/binhnguyennus/awesome-scalability) and found it to be a valuable resource for system enthusiasts.

While browsing through the repository, I noticed that it was missing links to any structured guides such as the famous ["roadmap.sh"](https://roadmap.sh). I took the initiative to submit a ["Pull Request"](https://github.com/binhnguyennus/awesome-scalability/pull/91) adding it in a separate section as Roadmap in which I added links to some of the roadmaps.

Thank you for your time and effort in maintaining this valuable resource :)

Best,
Mouaaz